### PR TITLE
Allow custom apiName when fetching DDF schema

### DIFF
--- a/src/SmartComponents/Applications/Applications.js
+++ b/src/SmartComponents/Applications/Applications.js
@@ -25,8 +25,8 @@ const Applications = ({ appsConfig, saveValues, match, getSchema, getConfig, con
     }, []);
 
     useEffect(() => {
-        if (currApp) {
-            getSchema(match.params.id, currApp.api);
+        if (currApp && typeof currApp !== 'string') {
+            getSchema(currApp?.api?.apiName || match.params.id, currApp.api);
         }
     }, [ currApp ]);
     return (
@@ -43,7 +43,7 @@ const Applications = ({ appsConfig, saveValues, match, getSchema, getConfig, con
                 <RenderForms
                     loaded={ loaded }
                     schemas={ schema }
-                    saveValues={ (values) => saveValues(match.params.id, values, currApp.api, currApp.title) }
+                    saveValues={ (values) => saveValues(currApp?.api?.apiName || match.params.id, values, currApp.api, currApp.title) }
                 />
             </Main>
         </React.Fragment>

--- a/src/api.js
+++ b/src/api.js
@@ -1,48 +1,15 @@
-import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
 import instance from '@redhat-cloud-services/frontend-components-utilities/files/interceptors';
 import { safeLoad } from 'js-yaml';
 
-export const getConfig = () => {
-    return instance.get(`${insights.chrome.isBeta() ? '/beta' : ''}/config/main.yml`)
-    .then(safeLoad);
+export const getConfig = async () => {
+    const config = await instance.get(`${insights.chrome.isBeta() ? '/beta' : ''}/config/main.yml`);
+    return safeLoad(config);
 };
 
-const localStorageKey = (application, user) => `@@settings-${application}-${user}`;
-const getLocalStorageItem = (key, subkey) => JSON.parse(localStorage.getItem(key) || '{}')[subkey];
+export const getApplicationSchema = async (application, apiVersion = 'v1') => (
+    instance.get(`/api/${application}/${apiVersion}/settings`)
+);
 
-const mockSchema = (application, user) => ([{
-    fields: [{
-        name: 'email',
-        label: 'Email',
-        component: componentTypes.TEXT_FIELD,
-        isRequired: true,
-        validate: [{
-            type: validatorTypes.REQUIRED
-        }],
-        initialValue: getLocalStorageItem(localStorageKey(application, user), 'email')
-    }, {
-        name: 'hideSatelliteSystems',
-        label: 'Hide Satellite systems',
-        component: componentTypes.SWITCH,
-        type: 'checkbox',
-        initialValue: getLocalStorageItem(localStorageKey(application, user), 'hideSatelliteSystems')
-    }]
-}]);
-
-const mockSave = (application, user, values) => localStorage.setItem(localStorageKey(application, user), JSON.stringify(values));
-
-export const getApplicationSchema = async (application, apiVersion = 'v1') => {
-    try {
-        return await instance.get(`/api/${application}/${apiVersion}/settings`);
-    } catch {
-        return insights.chrome.auth.getUser().then(({ identity }) => mockSchema(application, identity.user.username));
-    }
-};
-
-export const saveValues = async (application, values, apiVersion = 'v1') => {
-    try {
-        return await instance.post(`/api/${application}/${apiVersion}/settings/`, { ...values });
-    } catch {
-        return insights.chrome.auth.getUser().then(({ identity }) => mockSave(application, identity.user.username, values));
-    }
-};
+export const saveValues = async (application, values, apiVersion = 'v1') => (
+    instance.post(`/api/${application}/${apiVersion}/settings/`, { ...values })
+);


### PR DESCRIPTION
* Remove mocked schema so we don't show something dumb when the schema is not fetched
* If app defined custom `apiName` use it instead of URL id