### PR TITLE
Hide account level app settings for non org_admins

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -30,6 +30,14 @@ global.insights.chrome = {
     init() {},
     identifyApp() {},
     auth: {
-        getUser: () => Promise.resolve(({ identity: { user: { username: 'user' }}}))
+        getUser: () => Promise.resolve({
+            identity: {
+                user: {
+                    username: 'user',
+                    // eslint-disable-next-line camelcase
+                    is_org_admin: true
+                }
+            }
+        })
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1936,9 +1936,9 @@
       "integrity": "sha512-W3Kx2zlbfFtcjL9mYpjWNU9RfNrFpfXI6zC8qQTuaDwhV3IHCWt5HCkcf9oIW2aCtEjC0EkI67Wbz0BcmdYGJA=="
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-1.0.2.tgz",
-      "integrity": "sha512-0VOlTvfUt1JA+LzL+zm81/fh29tlP3r47IQVs3v+JgXftPAX+Mkr6hVt28+FM4S/G0iVk7poAfX8mMOqtvrB2w==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-1.0.28.tgz",
+      "integrity": "sha512-HIpSyvu2H2/l1iAAeRoXTnrQnAINt+QA2Gjjxp//NbzR8v4g7ZsA/u2fqu2Wj6KC1XfDwAOOTHialwfcsXNLwA==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": "*"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@patternfly/patternfly": "^2.62.0",
     "@patternfly/react-core": "3.134.2",
     "@patternfly/react-table": "^2.25.6",
-    "@redhat-cloud-services/frontend-components": "1.0.2",
+    "@redhat-cloud-services/frontend-components": "1.0.28",
     "@redhat-cloud-services/frontend-components-notifications": "^1.0.1",
     "@redhat-cloud-services/frontend-components-utilities": "1.0.0",
     "classnames": "^2.2.6",

--- a/src/SmartComponents/Applications/Applications.js
+++ b/src/SmartComponents/Applications/Applications.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { PageHeader, PageHeaderTitle, Main } from '@redhat-cloud-services/frontend-components';
+import { PageHeader, PageHeaderTitle, Main, NotAuthorized } from '@redhat-cloud-services/frontend-components';
 import { register } from '../../store';
 import reducers  from '../../store/reducers';
 import { notifications } from '@redhat-cloud-services/frontend-components-notifications';
@@ -15,7 +15,7 @@ export const getAppId = ({ params } = {}) => {
 const Applications = ({ appsConfig, saveValues, match, getSchema, getConfig, configLoaded, loaded, schema }) => {
     const currApp = appsConfig && appsConfig[getAppId(match)] || getAppId(match);
     const appName = ((currApp.frontend && currApp.frontend.title) || currApp.title) || currApp;
-    const [ user, setUser ] = useState(undefined);
+    const [ isOrgAmin, setIsOrgAdmin ] = useState(false);
 
     useEffect(() => {
         register(reducers);
@@ -24,7 +24,7 @@ const Applications = ({ appsConfig, saveValues, match, getSchema, getConfig, con
             getConfig();
         }
 
-        insights.chrome.auth.getUser().then((user) => setUser(user));
+        insights.chrome.auth.getUser().then((user) => setIsOrgAdmin(!user.identity.user.is_org_admin));
     }, []);
 
     useEffect(() => {
@@ -32,24 +32,26 @@ const Applications = ({ appsConfig, saveValues, match, getSchema, getConfig, con
             getSchema(currApp?.api?.apiName || match.params.id, currApp.api);
         }
     }, [ currApp ]);
+
     return (
         <React.Fragment>
             { configLoaded &&
                 <PageHeader>
                     <React.Fragment>
-                        <PageHeaderTitle title={ user && user.identity.user.is_org_admin ? 'Applications settings' : appName }/>
-                        <p>{ `Settings for ${appName}` }</p>
+                        <PageHeaderTitle title={ isOrgAmin ? 'Applications settings' : appName }/>
+                        { isOrgAmin && <p>{ `Settings for ${appName}` }</p>}
                     </React.Fragment>
                 </PageHeader>
             }
             <Main>
-                { user && user.identity.user.is_org_admin ?
+                { isOrgAmin ?
                     <RenderForms
                         loaded={ loaded }
                         schemas={ schema }
                         saveValues={ (values) => saveValues(currApp?.api?.apiName || match.params.id, values, currApp.api, currApp.title) }
                     />
-                    : <span>Not admin</span>}
+                    : <NotAuthorized serviceName={ appName }></NotAuthorized>
+                }
             </Main>
         </React.Fragment>
     );

--- a/src/SmartComponents/Applications/__snapshots__/applications.test.js.snap
+++ b/src/SmartComponents/Applications/__snapshots__/applications.test.js.snap
@@ -1,47 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Applications Render applications with emptyState 1`] = `
-<section
-  class="pf-l-page__main-section pf-c-page__main-section"
-  page-type=""
->
-  <div
-    class="pf-c-empty-state ins-c-not-authorized"
+Array [
+  <section
+    class="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+    widget-type="InsightsPageHeader"
   >
-    <svg
-      aria-hidden="true"
-      class="pf-c-empty-state__icon"
-      fill="currentColor"
-      height="1em"
-      role="img"
-      style="vertical-align:-0.125em"
-      viewBox="0 0 448 512"
-      width="1em"
+    <h1
+      class="pf-c-title pf-m-2xl"
+      widget-type="InsightsPageHeaderTitle"
     >
-      <path
-        d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
-        transform=""
-      />
-    </svg>
-    <h5
-      class="pf-c-title pf-m-lg"
-    >
-       You do not have access to testapp
-    </h5>
+       Testapp 
+    </h1>
+  </section>,
+  <section
+    class="pf-l-page__main-section pf-c-page__main-section"
+    page-type=""
+  >
     <div
-      class="pf-c-empty-state__body"
+      class="pf-c-empty-state ins-c-not-authorized"
     >
-      Contact your organization administrator(s) for more information.
+      <svg
+        aria-hidden="true"
+        class="pf-c-empty-state__icon"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align:-0.125em"
+        viewBox="0 0 448 512"
+        width="1em"
+      >
+        <path
+          d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+          transform=""
+        />
+      </svg>
+      <h5
+        class="pf-c-title pf-m-lg"
+      >
+         You do not have access to Testapp
+      </h5>
+      <div
+        class="pf-c-empty-state__body"
+      >
+        Contact your organization administrator(s) for more information.
+      </div>
+      <a
+        aria-disabled="false"
+        class="pf-c-button pf-m-primary"
+        href="."
+      >
+        Go to landing page
+      </a>
     </div>
-    <a
-      aria-disabled="false"
-      class="pf-c-button pf-m-primary"
-      href="."
-    >
-      Go to landing page
-    </a>
-  </div>
-</section>
+  </section>,
+]
 `;
 
 exports[`Applications Render applications with mockState 1`] = `
@@ -122,7 +135,7 @@ exports[`Applications Render applications with mockState 1`] = `
           widget-type="InsightsPageHeader"
         >
           <PageHeaderTitle
-            title="Test app"
+            title="Test App"
           >
             <Title
               className=""
@@ -134,7 +147,7 @@ exports[`Applications Render applications with mockState 1`] = `
                 widget-type="InsightsPageHeaderTitle"
               >
                  
-                Test app
+                Test App
                  
               </h1>
             </Title>
@@ -148,7 +161,7 @@ exports[`Applications Render applications with mockState 1`] = `
             page-type=""
           >
             <NotAuthorized
-              serviceName="Test app"
+              serviceName="Test App"
             >
               <EmptyState
                 className="ins-c-not-authorized"
@@ -198,7 +211,7 @@ exports[`Applications Render applications with mockState 1`] = `
                       className="pf-c-title pf-m-lg"
                     >
                        You do not have access to 
-                      Test app
+                      Test App
                     </h5>
                   </Title>
                   <EmptyStateBody>
@@ -262,45 +275,180 @@ exports[`Applications Render applications with mockState 1`] = `
 `;
 
 exports[`Applications Render applications with no data 1`] = `
-<section
-  class="pf-l-page__main-section pf-c-page__main-section"
-  page-type=""
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
 >
-  <div
-    class="pf-c-empty-state ins-c-not-authorized"
+  <Connect(Applications)
+    match={
+      Object {
+        "params": Object {
+          "id": "testapp",
+        },
+      }
+    }
   >
-    <svg
-      aria-hidden="true"
-      class="pf-c-empty-state__icon"
-      fill="currentColor"
-      height="1em"
-      role="img"
-      style="vertical-align:-0.125em"
-      viewBox="0 0 448 512"
-      width="1em"
+    <Applications
+      getConfig={[Function]}
+      getSchema={[Function]}
+      match={
+        Object {
+          "params": Object {
+            "id": "testapp",
+          },
+        }
+      }
+      saveValues={[Function]}
     >
-      <path
-        d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
-        transform=""
-      />
-    </svg>
-    <h5
-      class="pf-c-title pf-m-lg"
-    >
-       You do not have access to testapp
-    </h5>
-    <div
-      class="pf-c-empty-state__body"
-    >
-      Contact your organization administrator(s) for more information.
-    </div>
-    <a
-      aria-disabled="false"
-      class="pf-c-button pf-m-primary"
-      href="."
-    >
-      Go to landing page
-    </a>
-  </div>
-</section>
+      <PageHeader>
+        <section
+          className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+          widget-type="InsightsPageHeader"
+        >
+          <PageHeaderTitle
+            title="Testapp"
+          >
+            <Title
+              className=""
+              size="2xl"
+              widget-type="InsightsPageHeaderTitle"
+            >
+              <h1
+                className="pf-c-title pf-m-2xl"
+                widget-type="InsightsPageHeaderTitle"
+              >
+                 
+                Testapp
+                 
+              </h1>
+            </Title>
+          </PageHeaderTitle>
+        </section>
+      </PageHeader>
+      <Connect(Main)>
+        <Main>
+          <section
+            className="pf-l-page__main-section pf-c-page__main-section"
+            page-type=""
+          >
+            <NotAuthorized
+              serviceName="Testapp"
+            >
+              <EmptyState
+                className="ins-c-not-authorized"
+                variant="full"
+              >
+                <div
+                  className="pf-c-empty-state ins-c-not-authorized"
+                >
+                  <EmptyStateIcon
+                    icon={[Function]}
+                  >
+                    <LockIcon
+                      aria-hidden="true"
+                      className="pf-c-empty-state__icon"
+                      color="currentColor"
+                      noVerticalAlign={false}
+                      size="sm"
+                      title={null}
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-labelledby={null}
+                        className="pf-c-empty-state__icon"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style={
+                          Object {
+                            "verticalAlign": "-0.125em",
+                          }
+                        }
+                        viewBox="0 0 448 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+                          transform=""
+                        />
+                      </svg>
+                    </LockIcon>
+                  </EmptyStateIcon>
+                  <Title
+                    headingLevel="h5"
+                    size="lg"
+                  >
+                    <h5
+                      className="pf-c-title pf-m-lg"
+                    >
+                       You do not have access to 
+                      Testapp
+                    </h5>
+                  </Title>
+                  <EmptyStateBody>
+                    <div
+                      className="pf-c-empty-state__body"
+                    >
+                      Contact your organization administrator(s) for more information.
+                    </div>
+                  </EmptyStateBody>
+                  <Component
+                    component="a"
+                    href="."
+                    variant="primary"
+                  >
+                    <ComponentWithOuia
+                      component={[Function]}
+                      componentProps={
+                        Object {
+                          "children": "Go to landing page",
+                          "component": "a",
+                          "href": ".",
+                          "variant": "primary",
+                        }
+                      }
+                      consumerContext={null}
+                    >
+                      <Button
+                        component="a"
+                        href="."
+                        ouiaContext={
+                          Object {
+                            "isOuia": false,
+                            "ouiaId": null,
+                          }
+                        }
+                        variant="primary"
+                      >
+                        <a
+                          aria-disabled={false}
+                          aria-label={null}
+                          className="pf-c-button pf-m-primary"
+                          disabled={null}
+                          href="."
+                          tabIndex={null}
+                          type={null}
+                        >
+                          Go to landing page
+                        </a>
+                      </Button>
+                    </ComponentWithOuia>
+                  </Component>
+                </div>
+              </EmptyState>
+            </NotAuthorized>
+          </section>
+        </Main>
+      </Connect(Main)>
+    </Applications>
+  </Connect(Applications)>
+</Provider>
 `;

--- a/src/SmartComponents/Applications/__snapshots__/applications.test.js.snap
+++ b/src/SmartComponents/Applications/__snapshots__/applications.test.js.snap
@@ -1,225 +1,306 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Applications Render applications with emptyState 1`] = `
-Array [
-  <section
-    class="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
-    widget-type="InsightsPageHeader"
+<section
+  class="pf-l-page__main-section pf-c-page__main-section"
+  page-type=""
+>
+  <div
+    class="pf-c-empty-state ins-c-not-authorized"
   >
-    <h1
-      class="pf-c-title pf-m-2xl"
-      widget-type="InsightsPageHeaderTitle"
+    <svg
+      aria-hidden="true"
+      class="pf-c-empty-state__icon"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align:-0.125em"
+      viewBox="0 0 448 512"
+      width="1em"
     >
-       Applications settings 
-    </h1>
+      <path
+        d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+        transform=""
+      />
+    </svg>
+    <h5
+      class="pf-c-title pf-m-lg"
+    >
+       You do not have access to testapp
+    </h5>
     <div
-      class="ins-c-skeleton ins-c-skeleton__sm"
+      class="pf-c-empty-state__body"
     >
-       
+      Contact your organization administrator(s) for more information.
     </div>
-  </section>,
-  <section
-    class="pf-l-page__main-section pf-c-page__main-section"
-    page-type=""
-  >
-    <div
-      class="pf-l-stack pf-m-gutter"
+    <a
+      aria-disabled="false"
+      class="pf-c-button pf-m-primary"
+      href="."
     >
-      <div
-        class="pf-l-stack__item"
-      >
-        <article
-          class="pf-c-card"
-        >
-          <div
-            class="pf-c-card__body"
-          >
-            <div
-              class="ins-c-skeleton ins-c-skeleton__lg"
-            >
-               
-            </div>
-          </div>
-        </article>
-      </div>
-    </div>
-  </section>,
-]
+      Go to landing page
+    </a>
+  </div>
+</section>
 `;
 
 exports[`Applications Render applications with mockState 1`] = `
-Array [
-  <section
-    class="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
-    widget-type="InsightsPageHeader"
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(Applications)
+    match={
+      Object {
+        "params": Object {
+          "id": "testapp",
+        },
+      }
+    }
   >
-    <h1
-      class="pf-c-title pf-m-2xl"
-      widget-type="InsightsPageHeaderTitle"
+    <Applications
+      appsConfig={
+        Object {
+          "testapp": Object {
+            "frontend": Object {
+              "title": "Test app",
+            },
+          },
+        }
+      }
+      configLoaded={true}
+      getConfig={[Function]}
+      getSchema={[Function]}
+      loaded={true}
+      match={
+        Object {
+          "params": Object {
+            "id": "testapp",
+          },
+        }
+      }
+      saveValues={[Function]}
+      schema={
+        Array [
+          Object {
+            "fields": Array [
+              Object {
+                "component": "text-field",
+                "initialValue": "",
+                "isRequired": true,
+                "label": "Email",
+                "name": "email",
+                "validate": Array [
+                  Object {
+                    "type": "required-validator",
+                  },
+                ],
+              },
+              Object {
+                "component": "switch-field",
+                "initialValue": false,
+                "label": "Hide Satellite systems",
+                "name": "hideSatelliteSystems",
+                "type": "checkbox",
+              },
+            ],
+          },
+        ]
+      }
     >
-       Applications settings 
-    </h1>
-    <p>
-      Settings for Test app
-    </p>
-  </section>,
-  <section
-    class="pf-l-page__main-section pf-c-page__main-section"
-    page-type=""
-  >
-    <div
-      class="pf-l-stack pf-m-gutter"
-    >
-      <div
-        class="pf-l-stack__item"
-      >
-        <article
-          class="pf-c-card"
+      <PageHeader>
+        <section
+          className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+          widget-type="InsightsPageHeader"
         >
-          <div
-            class="pf-c-card__body"
+          <PageHeaderTitle
+            title="Test app"
           >
-            <form
-              class="pf-c-form"
-              novalidate=""
+            <Title
+              className=""
+              size="2xl"
+              widget-type="InsightsPageHeaderTitle"
             >
-              <div
-                class="pf-c-form__group"
+              <h1
+                className="pf-c-title pf-m-2xl"
+                widget-type="InsightsPageHeaderTitle"
               >
-                <label
-                  class="pf-c-form__label"
-                  for="email"
-                >
-                  <span
-                    class="pf-c-form__label-text"
-                  >
-                    Email
-                  </span>
-                  <span
-                    aria-hidden="true"
-                    class="pf-c-form__label-required"
-                  >
-                    *
-                  </span>
-                </label>
-                <input
-                  aria-invalid="false"
-                  class="pf-c-form-control"
-                  id="email"
-                  label="Email"
-                  name="email"
-                  type="text"
-                  value=""
-                />
-              </div>
-              <div
-                class="pf-c-form__group"
-              >
-                <label
-                  class="pf-c-switch"
-                  for="hideSatelliteSystems"
-                >
-                  <input
-                    aria-label=""
-                    aria-labelledby="hideSatelliteSystems-on"
-                    class="pf-c-switch__input"
-                    id="hideSatelliteSystems"
-                    name="hideSatelliteSystems"
-                    type="checkbox"
-                    value="false"
-                  />
-                  <span
-                    class="pf-c-switch__toggle"
-                  />
-                  <span
-                    aria-hidden="true"
-                    class="pf-c-switch__label pf-m-on"
-                    id="hideSatelliteSystems-on"
-                  >
-                    Hide Satellite systems
-                  </span>
-                  <span
-                    aria-hidden="true"
-                    class="pf-c-switch__label pf-m-off"
-                    id="hideSatelliteSystems-off"
-                  >
-                    Hide Satellite systems
-                  </span>
-                </label>
-              </div>
-              <div
-                class="pf-c-form__group pf-m-action"
+                 
+                Test app
+                 
+              </h1>
+            </Title>
+          </PageHeaderTitle>
+        </section>
+      </PageHeader>
+      <Connect(Main)>
+        <Main>
+          <section
+            className="pf-l-page__main-section pf-c-page__main-section"
+            page-type=""
+          >
+            <NotAuthorized
+              serviceName="Test app"
+            >
+              <EmptyState
+                className="ins-c-not-authorized"
+                variant="full"
               >
                 <div
-                  class="pf-c-form__actions"
+                  className="pf-c-empty-state ins-c-not-authorized"
                 >
-                  <button
-                    class="pf-c-button pf-m-primary"
-                    type="submit"
+                  <EmptyStateIcon
+                    icon={[Function]}
                   >
-                    Submit
-                  </button>
-                  <button
-                    class="pf-c-button pf-m-secondary"
-                    disabled=""
-                    type="button"
+                    <LockIcon
+                      aria-hidden="true"
+                      className="pf-c-empty-state__icon"
+                      color="currentColor"
+                      noVerticalAlign={false}
+                      size="sm"
+                      title={null}
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-labelledby={null}
+                        className="pf-c-empty-state__icon"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style={
+                          Object {
+                            "verticalAlign": "-0.125em",
+                          }
+                        }
+                        viewBox="0 0 448 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+                          transform=""
+                        />
+                      </svg>
+                    </LockIcon>
+                  </EmptyStateIcon>
+                  <Title
+                    headingLevel="h5"
+                    size="lg"
                   >
-                    Reset
-                  </button>
+                    <h5
+                      className="pf-c-title pf-m-lg"
+                    >
+                       You do not have access to 
+                      Test app
+                    </h5>
+                  </Title>
+                  <EmptyStateBody>
+                    <div
+                      className="pf-c-empty-state__body"
+                    >
+                      Contact your organization administrator(s) for more information.
+                    </div>
+                  </EmptyStateBody>
+                  <Component
+                    component="a"
+                    href="."
+                    variant="primary"
+                  >
+                    <ComponentWithOuia
+                      component={[Function]}
+                      componentProps={
+                        Object {
+                          "children": "Go to landing page",
+                          "component": "a",
+                          "href": ".",
+                          "variant": "primary",
+                        }
+                      }
+                      consumerContext={null}
+                    >
+                      <Button
+                        component="a"
+                        href="."
+                        ouiaContext={
+                          Object {
+                            "isOuia": false,
+                            "ouiaId": null,
+                          }
+                        }
+                        variant="primary"
+                      >
+                        <a
+                          aria-disabled={false}
+                          aria-label={null}
+                          className="pf-c-button pf-m-primary"
+                          disabled={null}
+                          href="."
+                          tabIndex={null}
+                          type={null}
+                        >
+                          Go to landing page
+                        </a>
+                      </Button>
+                    </ComponentWithOuia>
+                  </Component>
                 </div>
-              </div>
-            </form>
-          </div>
-        </article>
-      </div>
-    </div>
-  </section>,
-]
+              </EmptyState>
+            </NotAuthorized>
+          </section>
+        </Main>
+      </Connect(Main)>
+    </Applications>
+  </Connect(Applications)>
+</Provider>
 `;
 
 exports[`Applications Render applications with no data 1`] = `
-Array [
-  <section
-    class="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
-    widget-type="InsightsPageHeader"
+<section
+  class="pf-l-page__main-section pf-c-page__main-section"
+  page-type=""
+>
+  <div
+    class="pf-c-empty-state ins-c-not-authorized"
   >
-    <h1
-      class="pf-c-title pf-m-2xl"
-      widget-type="InsightsPageHeaderTitle"
+    <svg
+      aria-hidden="true"
+      class="pf-c-empty-state__icon"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align:-0.125em"
+      viewBox="0 0 448 512"
+      width="1em"
     >
-       Applications settings 
-    </h1>
+      <path
+        d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+        transform=""
+      />
+    </svg>
+    <h5
+      class="pf-c-title pf-m-lg"
+    >
+       You do not have access to testapp
+    </h5>
     <div
-      class="ins-c-skeleton ins-c-skeleton__sm"
+      class="pf-c-empty-state__body"
     >
-       
+      Contact your organization administrator(s) for more information.
     </div>
-  </section>,
-  <section
-    class="pf-l-page__main-section pf-c-page__main-section"
-    page-type=""
-  >
-    <div
-      class="pf-l-stack pf-m-gutter"
+    <a
+      aria-disabled="false"
+      class="pf-c-button pf-m-primary"
+      href="."
     >
-      <div
-        class="pf-l-stack__item"
-      >
-        <article
-          class="pf-c-card"
-        >
-          <div
-            class="pf-c-card__body"
-          >
-            <div
-              class="ins-c-skeleton ins-c-skeleton__lg"
-            >
-               
-            </div>
-          </div>
-        </article>
-      </div>
-    </div>
-  </section>,
-]
+      Go to landing page
+    </a>
+  </div>
+</section>
 `;

--- a/src/SmartComponents/Applications/applications.test.js
+++ b/src/SmartComponents/Applications/applications.test.js
@@ -57,17 +57,13 @@ describe('Applications', () => {
         mockStore = configureStore([ createPromise(), notificationsMiddleware() ]);
     });
 
-    it('Render applications with no data', async(done) => {
+    it('Render applications with no data', () => {
         const store = mockStore({});
-        let wrapper;
-        await act(async () => {
-            wrapper = mount(<Provider store={ store }>
-                <Applications match={ { params: { id: 'testapp' }} }/>
-            </Provider>);
-        });
+        const wrapper = mount(<Provider store={ store }>
+            <Applications match={ { params: { id: 'testapp' }} }/>
+        </Provider>);
         wrapper.update();
         expect(toJson(wrapper)).toMatchSnapshot();
-        done();
     });
 
     it('Render applications with emptyState', () => {
@@ -78,50 +74,49 @@ describe('Applications', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('Render applications with mockState', async(done) => {
+    it('Render applications with mockState', () => {
         const store = mockStore(mockState);
-        let wrapper;
-        await act(async () => {
-            wrapper = mount(<Provider store={ store }>
-                <Applications match={ { params: { id: 'testapp' }} } />
-            </Provider>);
-        });
+        const wrapper = mount(<Provider store={ store }>
+            <Applications match={ { params: { id: 'testapp' }} } />
+        </Provider>);
         wrapper.update();
         expect(toJson(wrapper)).toMatchSnapshot();
-        done();
     });
 
-    it('should emit type-success notification on saving a form', async(done) => {
+    it('should emit type-success notification on saving a form', () => {
         const store = mockStore(mockState);
         let wrapper;
-        await act(async () => {
+        act(async () => {
             wrapper = mount(
                 <Provider store={ store }>
                     <Applications appsConfig={ {} } match={ { params: { id: 'testapp' }} } />
                 </Provider>
             );
+
+            wrapper.update();
         });
-        wrapper.update();
-        const input = wrapper.find('input#email');
-        input.getDOMNode().value = 'value';
-        input.simulate('change');
-        wrapper.update();
-        wrapper.find('form.pf-c-form').simulate('submit');
-        const expectedPayload = [
-            expect.anything(),
-            expect.objectContaining({
-                meta: { notifications: {
-                    fulfilled: {
-                        description: 'Settings for Red Hat Insights were replaced with new values.',
-                        dismissable: true,
-                        title: 'Application settings saved',
-                        variant: 'success'
-                    }
-                }}
-            })
-        ];
-        wrapper.update();
-        expect(store.getActions()).toEqual(expectedPayload);
-        done();
+        setImmediate(async(done) => {
+            const input = wrapper.find('input#email');
+            input.getDOMNode().value = 'value';
+            input.simulate('change');
+            wrapper.update();
+            wrapper.find('form.pf-c-form').simulate('submit');
+            const expectedPayload = [
+                expect.anything(),
+                expect.objectContaining({
+                    meta: { notifications: {
+                        fulfilled: {
+                            description: 'Settings for Red Hat Insights were replaced with new values.',
+                            dismissable: true,
+                            title: 'Application settings saved',
+                            variant: 'success'
+                        }
+                    }}
+                })
+            ];
+            wrapper.update();
+            expect(store.getActions()).toEqual(expectedPayload);
+            done();
+        });
     });
 });

--- a/src/SmartComponents/Applications/applications.test.js
+++ b/src/SmartComponents/Applications/applications.test.js
@@ -7,6 +7,7 @@ import { createPromise } from 'redux-promise-middleware';
 import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications';
 import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
 import Applications from './Applications';
+import { act } from 'react-dom/test-utils';
 import { init } from '../../store';
 
 const emptyState = {
@@ -56,12 +57,17 @@ describe('Applications', () => {
         mockStore = configureStore([ createPromise(), notificationsMiddleware() ]);
     });
 
-    it('Render applications with no data', () => {
+    it('Render applications with no data', async(done) => {
         const store = mockStore({});
-        const wrapper = render(<Provider store={ store }>
-            <Applications match={ { params: { id: 'testapp' }} }/>
-        </Provider>);
+        let wrapper;
+        await act(async () => {
+            wrapper = mount(<Provider store={ store }>
+                <Applications match={ { params: { id: 'testapp' }} }/>
+            </Provider>);
+        });
+        wrapper.update();
         expect(toJson(wrapper)).toMatchSnapshot();
+        done();
     });
 
     it('Render applications with emptyState', () => {
@@ -72,21 +78,30 @@ describe('Applications', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('Render applications with mockState', () => {
+    it('Render applications with mockState', async(done) => {
         const store = mockStore(mockState);
-        const wrapper = render(<Provider store={ store }>
-            <Applications match={ { params: { id: 'testapp' }} } />
-        </Provider>);
+        let wrapper;
+        await act(async () => {
+            wrapper = mount(<Provider store={ store }>
+                <Applications match={ { params: { id: 'testapp' }} } />
+            </Provider>);
+        });
+        wrapper.update();
         expect(toJson(wrapper)).toMatchSnapshot();
+        done();
     });
 
-    it('should emit type-success notification on saving a form', () => {
+    it('should emit type-success notification on saving a form', async(done) => {
         const store = mockStore(mockState);
-        const wrapper = mount(
-            <Provider store={ store }>
-                <Applications appsConfig={ {} } match={ { params: { id: 'testapp' }} } />
-            </Provider>
-        );
+        let wrapper;
+        await act(async () => {
+            wrapper = mount(
+                <Provider store={ store }>
+                    <Applications appsConfig={ {} } match={ { params: { id: 'testapp' }} } />
+                </Provider>
+            );
+        });
+        wrapper.update();
         const input = wrapper.find('input#email');
         input.getDOMNode().value = 'value';
         input.simulate('change');
@@ -107,5 +122,6 @@ describe('Applications', () => {
         ];
         wrapper.update();
         expect(store.getActions()).toEqual(expectedPayload);
+        done();
     });
 });


### PR DESCRIPTION
- If user is org-admin, they see app setting navigation and options
- If user is not org-admin, they should see app setting navigation but if they click on anything they will get an empty state
- If the user is not entitled, they should not see items in the app setting navigation at all
- updated tests

![001](https://user-images.githubusercontent.com/50696716/82996887-f130a880-a005-11ea-9d51-cd55e36b1729.png)

uses https://github.com/RedHatInsights/frontend-components/pull/510

@karelhala 